### PR TITLE
Explicitly require pyglottolog

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     },
     install_requires=[
         'cldfbench',
+        'pyglottolog',
         'geopandas',
         'shapely',
     ],


### PR DESCRIPTION
Otherwise the command `mergeglottocodes` is not available.